### PR TITLE
Upgrade deps, quell warnings, bump version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
    {src_dirs, ["test", "src"]}
   ]}.
 {deps, [
-   {lfe, ".*", {git, "git://github.com/rvirding/lfe.git", {tag, "v0.9.1"}}},
+   {lfe, ".*", {git, "git://github.com/rvirding/lfe.git", {tag, "v0.9.2"}}},
    {lutil, ".*", {git, "https://github.com/lfex/lutil.git", {tag, "0.6.5"}}},
    {clj, ".*", {git, "https://github.com/lfex/clj.git", {branch, "master"}}},
    {ltest, ".*", {git, "git://github.com/lfex/ltest.git", {tag, "0.6.1"}}}

--- a/src/exemplar-html-util.lfe
+++ b/src/exemplar-html-util.lfe
@@ -26,13 +26,13 @@
     (doctype arg1 arg2)))
 
 (defun make-html
-  (("!doctype" data)
+  (('"!doctype" data)
     (io_lib:format (++ (handle-doctype data) "~n") '()))
-  (("link" attrs)
+  (('"link" attrs)
     (exemplar:non-closing-tag "link" attrs))
-  (("meta" attrs)
+  (('"meta" attrs)
     (exemplar:non-closing-tag "meta" attrs))
-  (("script" content-or-attrs)
+  (('"script" content-or-attrs)
     (cond
      ((attrs? content-or-attrs)
       (make-html "script" content-or-attrs ""))

--- a/src/exemplar.app.src
+++ b/src/exemplar.app.src
@@ -2,10 +2,10 @@
 {application, 'exemplar',
  [
   %% A quick description of the application.
-  {description, "My project description..."},
+  {description, "HTML as S-Expressions for LFE"},
 
   %% The version of the application
-  {vsn, "0.1.1"},
+  {vsn, "0.1.2"},
 
   %% All modules used by the application.
   {modules,


### PR DESCRIPTION
commit de7f6e2d183ace649b40ca88f6b2340721246fa2
Author: @yurrriq
Date:   Fri Aug 21 17:11:48 2015 -0500

> Bump version to 0.1.2
>
> Also add project description from package.exs (removed d128221bc0aa03aa5c33d5876260a5dc2edd0342) to exemplar.app.src.

==================================================

commit 8eea49853306a18618e015681c87362407fe7a05
Author: @yurrriq
Date:   Fri Aug 21 17:07:20 2015 -0500

> Quell compiler warnings by quoting string literals in patterns

**Before**:
```
src/exemplar-html-util.lfe:28: Warning: deprecated pattern
src/exemplar-html-util.lfe:28: Warning: deprecated pattern
src/exemplar-html-util.lfe:28: Warning: deprecated pattern
src/exemplar-html-util.lfe:28: Warning: deprecated pattern
Compiled src/exemplar-html-util.lfe
```

**After**:
```
Compiled src/exemplar-html-util.lfe
```

==================================================

commit 10597151c9b2a8f259b529a76fba974f7d978942
Author: @yurrriq
Date:   Fri Aug 21 17:04:46 2015 -0500

> Upgrade lfe dependency, v0.9.1 => v0.9.2